### PR TITLE
Bugfix: Cannot read property 'style' of null.

### DIFF
--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -318,6 +318,9 @@ var DragDropTouch;
         DragDropTouch.prototype._moveImage = function (e) {
             var _this = this;
             requestAnimationFrame(function () {
+                if (!_this._img) {
+                    return;
+                }
                 var pt = _this._getPoint(e, true), s = _this._img.style;
                 s.position = 'fixed';
                 s.pointerEvents = 'none';


### PR DESCRIPTION
When dragging fast in any direction and dropping while the mouse is
still moving the JS error "Cannot read property 'style' of null"
appeared.
This change fixes it.